### PR TITLE
Fix category url_key and url_path returning null

### DIFF
--- a/internal/repository/aggregation.go
+++ b/internal/repository/aggregation.go
@@ -281,9 +281,9 @@ func (r *AggregationRepository) GetCategoryAggregation(ctx context.Context, matc
 		FROM catalog_category_product ccp
 		JOIN catalog_category_entity cce ON ccp.category_id = cce.entity_id
 		LEFT JOIN catalog_category_entity_varchar ccevn_d ON cce.entity_id = ccevn_d.entity_id
-			AND ccevn_d.attribute_id = 45 AND ccevn_d.store_id = 0
+			AND ccevn_d.attribute_id = (SELECT attribute_id FROM eav_attribute WHERE attribute_code = 'name' AND entity_type_id = 3) AND ccevn_d.store_id = 0
 		LEFT JOIN catalog_category_entity_varchar ccevn_s ON cce.entity_id = ccevn_s.entity_id
-			AND ccevn_s.attribute_id = 45 AND ccevn_s.store_id = %d
+			AND ccevn_s.attribute_id = (SELECT attribute_id FROM eav_attribute WHERE attribute_code = 'name' AND entity_type_id = 3) AND ccevn_s.store_id = %d
 		WHERE ccp.product_id IN (`+strings.Join(placeholders, ",")+`)
 		AND cce.level > 1
 		GROUP BY ccp.category_id, label

--- a/internal/repository/category.go
+++ b/internal/repository/category.go
@@ -63,16 +63,16 @@ func (r *CategoryRepository) GetCategoriesForProducts(ctx context.Context, entit
 			COALESCE(active_s.value, active_d.value) AS is_active
 		FROM catalog_category_product ccp
 		INNER JOIN catalog_category_entity cce ON ccp.category_id = cce.entity_id
-		LEFT JOIN catalog_category_entity_varchar name_d ON cce.entity_id = name_d.entity_id AND name_d.attribute_id = 45 AND name_d.store_id = 0
-		LEFT JOIN catalog_category_entity_varchar name_s ON cce.entity_id = name_s.entity_id AND name_s.attribute_id = 45 AND name_s.store_id = %d
-		LEFT JOIN catalog_category_entity_varchar urlkey_d ON cce.entity_id = urlkey_d.entity_id AND urlkey_d.attribute_id = 124 AND urlkey_d.store_id = 0
-		LEFT JOIN catalog_category_entity_varchar urlkey_s ON cce.entity_id = urlkey_s.entity_id AND urlkey_s.attribute_id = 124 AND urlkey_s.store_id = %d
-		LEFT JOIN catalog_category_entity_varchar urlpath_d ON cce.entity_id = urlpath_d.entity_id AND urlpath_d.attribute_id = 125 AND urlpath_d.store_id = 0
-		LEFT JOIN catalog_category_entity_varchar urlpath_s ON cce.entity_id = urlpath_s.entity_id AND urlpath_s.attribute_id = 125 AND urlpath_s.store_id = %d
-		LEFT JOIN catalog_category_entity_text desc_d ON cce.entity_id = desc_d.entity_id AND desc_d.attribute_id = 47 AND desc_d.store_id = 0
-		LEFT JOIN catalog_category_entity_text desc_s ON cce.entity_id = desc_s.entity_id AND desc_s.attribute_id = 47 AND desc_s.store_id = %d
-		LEFT JOIN catalog_category_entity_int active_d ON cce.entity_id = active_d.entity_id AND active_d.attribute_id = 46 AND active_d.store_id = 0
-		LEFT JOIN catalog_category_entity_int active_s ON cce.entity_id = active_s.entity_id AND active_s.attribute_id = 46 AND active_s.store_id = %d
+		LEFT JOIN catalog_category_entity_varchar name_d ON cce.entity_id = name_d.entity_id AND name_d.attribute_id = (SELECT attribute_id FROM eav_attribute WHERE attribute_code = 'name' AND entity_type_id = 3) AND name_d.store_id = 0
+		LEFT JOIN catalog_category_entity_varchar name_s ON cce.entity_id = name_s.entity_id AND name_s.attribute_id = (SELECT attribute_id FROM eav_attribute WHERE attribute_code = 'name' AND entity_type_id = 3) AND name_s.store_id = %d
+		LEFT JOIN catalog_category_entity_varchar urlkey_d ON cce.entity_id = urlkey_d.entity_id AND urlkey_d.attribute_id = (SELECT attribute_id FROM eav_attribute WHERE attribute_code = 'url_key' AND entity_type_id = 3) AND urlkey_d.store_id = 0
+		LEFT JOIN catalog_category_entity_varchar urlkey_s ON cce.entity_id = urlkey_s.entity_id AND urlkey_s.attribute_id = (SELECT attribute_id FROM eav_attribute WHERE attribute_code = 'url_key' AND entity_type_id = 3) AND urlkey_s.store_id = %d
+		LEFT JOIN catalog_category_entity_varchar urlpath_d ON cce.entity_id = urlpath_d.entity_id AND urlpath_d.attribute_id = (SELECT attribute_id FROM eav_attribute WHERE attribute_code = 'url_path' AND entity_type_id = 3) AND urlpath_d.store_id = 0
+		LEFT JOIN catalog_category_entity_varchar urlpath_s ON cce.entity_id = urlpath_s.entity_id AND urlpath_s.attribute_id = (SELECT attribute_id FROM eav_attribute WHERE attribute_code = 'url_path' AND entity_type_id = 3) AND urlpath_s.store_id = %d
+		LEFT JOIN catalog_category_entity_text desc_d ON cce.entity_id = desc_d.entity_id AND desc_d.attribute_id = (SELECT attribute_id FROM eav_attribute WHERE attribute_code = 'description' AND entity_type_id = 3) AND desc_d.store_id = 0
+		LEFT JOIN catalog_category_entity_text desc_s ON cce.entity_id = desc_s.entity_id AND desc_s.attribute_id = (SELECT attribute_id FROM eav_attribute WHERE attribute_code = 'description' AND entity_type_id = 3) AND desc_s.store_id = %d
+		LEFT JOIN catalog_category_entity_int active_d ON cce.entity_id = active_d.entity_id AND active_d.attribute_id = (SELECT attribute_id FROM eav_attribute WHERE attribute_code = 'is_active' AND entity_type_id = 3) AND active_d.store_id = 0
+		LEFT JOIN catalog_category_entity_int active_s ON cce.entity_id = active_s.entity_id AND active_s.attribute_id = (SELECT attribute_id FROM eav_attribute WHERE attribute_code = 'is_active' AND entity_type_id = 3) AND active_s.store_id = %d
 		WHERE ccp.product_id IN (%s)
 		AND cce.level > 1
 		ORDER BY cce.level ASC, cce.position ASC


### PR DESCRIPTION
Closes #2. Replace hardcoded attribute IDs with dynamic subqueries. Verified: categories comparison now IDENTICAL to Magento PHP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)