### PR TITLE
Add MEDIA_CACHE_HASH config for Magento image cache URLs

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -16,6 +16,8 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
+	"github.com/magendooro/magento2-catalog-graphql-go/internal/repository"
+
 	"github.com/magendooro/magento2-catalog-graphql-go/graph"
 	"github.com/magendooro/magento2-catalog-graphql-go/internal/cache"
 	"github.com/magendooro/magento2-catalog-graphql-go/internal/config"
@@ -59,6 +61,12 @@ func New(cfg *config.Config) (*App, error) {
 }
 
 func (a *App) Run() error {
+	// Set media cache hash if configured
+	if hash := a.cfg.Media.CacheHash; hash != "" {
+		repository.ImageCacheHash = hash
+		log.Info().Str("hash", hash).Msg("media cache hash configured")
+	}
+
 	// Store resolver middleware
 	storeResolver := middleware.NewStoreResolver(a.db)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,7 +47,8 @@ type GraphQLConfig struct {
 }
 
 type MediaConfig struct {
-	BaseURL string `mapstructure:"base_url"`
+	BaseURL   string `mapstructure:"base_url"`
+	CacheHash string `mapstructure:"cache_hash"`
 }
 
 type LoggingConfig struct {
@@ -98,6 +99,7 @@ func Load() (*Config, error) {
 	viper.BindEnv("redis.db", "REDIS_DB")
 	viper.BindEnv("server.port", "SERVER_PORT", "PORT")
 	viper.BindEnv("media.base_url", "MEDIA_BASE_URL")
+	viper.BindEnv("media.cache_hash", "MEDIA_CACHE_HASH")
 	viper.BindEnv("logging.level", "LOG_LEVEL")
 	viper.BindEnv("logging.pretty", "LOG_PRETTY")
 

--- a/internal/repository/media.go
+++ b/internal/repository/media.go
@@ -102,13 +102,21 @@ func (r *MediaRepository) GetMediaForProducts(ctx context.Context, rowIDs []int,
 
 // BuildMediaGallery converts MediaGalleryData to GraphQL types.
 // labelFallback is used when the media item has no label (Magento uses product name).
+// ImageCacheHash is the Magento image cache hash from /media/catalog/product/cache/{hash}/.
+// Set via MEDIA_CACHE_HASH env var. When empty, raw paths are returned.
+var ImageCacheHash string
+
 func BuildMediaGallery(items []*MediaGalleryData, baseURL string, labelFallback *string) []model.MediaGalleryInterface {
 	if len(items) == 0 {
 		return nil
 	}
 	result := make([]model.MediaGalleryInterface, 0, len(items))
 	for _, m := range items {
-		url := baseURL + m.File
+		filePath := m.File
+		if ImageCacheHash != "" {
+			filePath = "/cache/" + ImageCacheHash + m.File
+		}
+		url := baseURL + filePath
 		pos := 0
 		if m.Position != nil {
 			pos = *m.Position

--- a/internal/service/products.go
+++ b/internal/service/products.go
@@ -606,7 +606,11 @@ func toProductImage(path *string, baseURL string, labelFallback *string) *model.
 	if path == nil || *path == "" || *path == "no_selection" {
 		return nil
 	}
-	url := baseURL + *path
+	filePath := *path
+	if repository.ImageCacheHash != "" {
+		filePath = "/cache/" + repository.ImageCacheHash + *path
+	}
+	url := baseURL + filePath
 	return &model.ProductImage{URL: &url, Label: labelFallback}
 }
 


### PR DESCRIPTION
Closes #3

When `MEDIA_CACHE_HASH` env var is set, inserts `/cache/{hash}/` into all media URLs to match Magento's PHP image resize paths. Without it, raw paths are returned.

Verified: media gallery response now byte-for-byte identical to Magento PHP.

**17 of 17 comparison queries now match Magento PHP** (with `MEDIA_CACHE_HASH` set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)