### PR TITLE
fix: enable SkipMutations in catalog cache middleware

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -103,7 +103,7 @@ func (a *App) Run() error {
 
 	// Catalog caches all GraphQL responses — no auth, no mutations
 	var h http.Handler = mux
-	h = middleware.CacheMiddleware(a.cache, middleware.CacheOptions{})(h)
+	h = middleware.CacheMiddleware(a.cache, middleware.CacheOptions{SkipMutations: true})(h)
 	h = middleware.StoreMiddleware(storeResolver)(h)
 	h = middleware.LoggingMiddleware(h)
 	h = middleware.CORSMiddleware(h)


### PR DESCRIPTION
## Summary

- Add `SkipMutations: true` to `CacheOptions` in `internal/app/app.go`
- Catalog was previously caching all POST /graphql requests, including mutations
- Uses the JSON-parsed operation type check from go-common (no false positives on field names)

## Test plan

- [x] `go build` passes
- [x] `go vet` passes
- [ ] Integration tests (excluding pre-existing `TestProductsMediaGallery` panic unrelated to this change)

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)